### PR TITLE
Expose sendfile kernel copying for Linux, OS X, FreeBSD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.6
 _*
 6.out
+*.swp
+tags
 bin
 examples/hot_restart/hot_restart
 examples/hello_world/hello_world

--- a/server.go
+++ b/server.go
@@ -71,7 +71,11 @@ func (srv *Server) socketListen() error {
 		if srv.listenerFile, err = l.File(); err != nil {
 			return err
 		}
-		if e := setupFDNonblock(int(srv.listenerFile.Fd())); e != nil {
+		fd := int(srv.listenerFile.Fd())
+		if e := setupFDNonblock(fd); e != nil {
+			return e
+		}
+		if e := syscall.SetsockoptInt(fd, syscall.SOL_TCP , syscall.TCP_NODELAY , 1); e != nil {
 			return e
 		}
 	}

--- a/server.go
+++ b/server.go
@@ -10,13 +10,12 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"reflect"
+	"runtime"
 	"strconv"
 	"sync"
 	"syscall"
 	"time"
-	
-	"reflect"
-	"runtime"
 )
 
 type Server struct {
@@ -28,6 +27,8 @@ type Server struct {
 	handlerWaitGroup *sync.WaitGroup
 	logPrefix        string
 	AcceptReady      chan int
+	sendfile         bool
+	sockOpt          int
 }
 
 func NewServer(port int, pipeline *Pipeline) *Server {
@@ -38,6 +39,20 @@ func NewServer(port int, pipeline *Pipeline) *Server {
 	s.AcceptReady = make(chan int, 1)
 	s.handlerWaitGroup = new(sync.WaitGroup)
 	s.logPrefix = fmt.Sprintf("%d", syscall.Getpid())
+
+	// openbsd/netbsd don't have TCP_NOPUSH so it's likely sendfile will be slower
+	// without these socket options, just enable for linux, mac and freebsd.
+	// TODO (Graham) windows has TransmitFile zero-copy mechanism, try to use it
+	switch runtime.GOOS {
+	case "linux":
+		s.sendfile = true
+		s.sockOpt = 0x3 // syscall.TCP_CORK
+	case "freebsd", "darwin":
+		s.sendfile = true
+		s.sockOpt = 0x4 // syscall.TCP_NOPUSH
+	default:
+		s.sendfile = false
+	}
 	return s
 }
 
@@ -75,8 +90,11 @@ func (srv *Server) socketListen() error {
 		if e := setupFDNonblock(fd); e != nil {
 			return e
 		}
-		if e := syscall.SetsockoptInt(fd, syscall.SOL_TCP , syscall.TCP_NODELAY , 1); e != nil {
-			return e
+
+		if srv.sendfile {
+			if e := syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, srv.sockOpt, 1); e != nil {
+				return e
+			}
 		}
 	}
 	return nil
@@ -96,10 +114,8 @@ func setupFDNonblock(fd int) error {
 			}
 		}
 	}
-	
 	return nil
 }
-
 
 func (srv *Server) ListenAndServe() error {
 	if srv.Addr == "" {
@@ -224,9 +240,15 @@ func (srv *Server) handler(c net.Conn) {
 			// cleanup
 			request.startPipelineStage("server.ResponseWrite")
 			req.Body.Close()
-			wbuf := bufio.NewWriter(c)
-			res.Write(wbuf)
-			wbuf.Flush()
+
+			if srv.sendfile {
+				res.Write(c)
+			} else {
+				wbuf := bufio.NewWriter(c)
+				res.Write(wbuf)
+				wbuf.Flush()
+			}
+
 			if res.Body != nil {
 				res.Body.Close()
 			}


### PR DESCRIPTION
Hey guys,

Please review and bench this changset, I see a nice improvement in throughput and requests/sec for the static file filter and unchanged for any other response. My benches were on Linux x86_64, quad core with HT enabled. 

Here are my benches for the changeset:
### Bench Tool

```
weighttp -t 8 -c 1000 -n 1000000 http://localhost:8080/bench/100.html
```
#### 100 bytes - 1k concurrent, 1million requests
- Before: finished in 27 sec, 188 millisec and 738 microsec, 36779 req/s, 6465 kbyte/s
- After:    finished in 23 sec, 146 millisec and 721 microsec, 43202 req/s, 7594 kbyte/s
- +17%
#### 4 k - 1k concurrent, 1million requests
- Before finished in 29 sec, 186 millisec and 568 microsec, 34262 req/s, 139759 kbyte/s
- After: finished in 23 sec, 848 millisec and 815 microsec, 41930 req/s, 171040 kbyte/s
- +22%
#### 20k - 1k concurrent, 1million requests
- Before: finished in 34 sec, 25 millisec and 300 microsec, 29389 req/s, 590151 kbyte/s
- After: finished in 25 sec, 535 millisec and 173 microsec, 39161 req/s, 786369 kbyte/s
- +33%
#### 1MB - 100 concurrent, 1million requests
- Before: finished in 241 sec, 135 millisec and 750 microsec, 4147 req/s, 4246910 kbyte/s
- After: finished in 108 sec, 479 millisec and 387 microsec, 9218 req/s, 9440337 kbyte/s
- +122%
#### 404 response, no file copy - 1k concurrent, 1million requests
- Before: finished in 26 sec, 521 millisec and 28 microsec, 37705 req/s, 2246 kbyte/s
- After: finished in 26 sec, 631 millisec and 12 microsec, 37550 req/s, 2236 kbyte/s
- -0.5%
