### PR TITLE
Reuse conn buffer

### DIFF
--- a/buffer_pool.go
+++ b/buffer_pool.go
@@ -1,0 +1,65 @@
+package falcore
+
+import (
+	"io"
+	"bufio"
+)
+
+// uses a chan as a leaky bucket buffer pool
+type bufferPool struct {
+	// size of buffer when creating new ones
+	bufSize int
+	// the actual pool of buffers ready for reuse
+	pool chan *bufferPoolEntry
+	// this is used for draining a buffer to prep for reuse
+	drain []byte
+}
+
+// This is what's stored in the buffer.  It allows
+// for the underlying io.Reader to be changed out
+// inside a bufio.Reader.  This is required for reuse.
+type bufferPoolEntry struct {
+	buf *bufio.Reader
+	source io.Reader
+}
+
+// make bufferPoolEntry a passthrough io.Reader
+func (bpe *bufferPoolEntry) Read(p []byte) (n int, err error) {
+	return bpe.source.Read(p)
+}
+
+func newBufferPool(poolSize, bufferSize int) *bufferPool {
+	return &bufferPool{
+		bufSize: bufferSize,
+		pool: make(chan *bufferPoolEntry, poolSize),
+		drain: make([]byte, bufferSize),
+	}
+}
+
+// Take a buffer from the pool and set 
+// it up to read from r
+func (p *bufferPool) take(r io.Reader)(bpe *bufferPoolEntry) {
+	select {
+		case bpe = <- p.pool:
+			// prepare for reuse
+			if a := bpe.buf.Buffered(); a > 0 {
+				// drain the internal buffer
+				bpe.buf.Read(p.drain[0:a])
+			}
+			// swap out the underlying reader
+			bpe.source = r
+		default:
+			// none available.  create a new one
+			bpe = &bufferPoolEntry{bufio.NewReaderSize(r, p.bufSize), r}
+	}
+	return
+}
+
+// Return a buffer to the pool
+func (p *bufferPool) give(bpe *bufferPoolEntry) {
+	select {
+		case p.pool <- bpe: // return to pool
+		default: // discard
+	}
+}
+

--- a/buffer_pool.go
+++ b/buffer_pool.go
@@ -50,7 +50,8 @@ func (p *bufferPool) take(r io.Reader)(bpe *bufferPoolEntry) {
 			bpe.source = r
 		default:
 			// none available.  create a new one
-			bpe = &bufferPoolEntry{bufio.NewReaderSize(r, p.bufSize), r}
+			bpe = &bufferPoolEntry{nil, r}
+			bpe.buf = bufio.NewReaderSize(bpe, p.bufSize)
 	}
 	return
 }

--- a/buffer_pool_test.go
+++ b/buffer_pool_test.go
@@ -15,7 +15,7 @@ func TestBufferPool(t *testing.T) {
 	bpe := pool.take(bytes.NewBuffer(text))
 	// read all
 	out := make([]byte, 1024)
-	l, _ := bpe.buf.Read(out)
+	l, _ := bpe.br.Read(out)
 	if bytes.Compare(out[0:l], text) != 0 {
 		t.Errorf("Read invalid data: %v", out)
 	}
@@ -28,7 +28,7 @@ func TestBufferPool(t *testing.T) {
 	bpe = pool.take(bytes.NewBuffer(text))
 	// read all
 	out = make([]byte, 1024)
-	l, _ = bpe.buf.Read(out)
+	l, _ = bpe.br.Read(out)
 	if bytes.Compare(out[0:l], text) != 0 {
 		t.Errorf("Read invalid data: %v", out)
 	}
@@ -41,14 +41,14 @@ func TestBufferPool(t *testing.T) {
 	bpe = pool.take(bytes.NewBuffer(text))
 	// read 1 byte
 	out = make([]byte, 1)
-	bpe.buf.Read(out)
+	bpe.br.Read(out)
 	pool.give(bpe)
 
 	// get one
 	bpe = pool.take(bytes.NewBuffer(text))
 	// read all
 	out = make([]byte, 1024)
-	l, _ = bpe.buf.Read(out)
+	l, _ = bpe.br.Read(out)
 	if bytes.Compare(out[0:l], text) != 0 {
 		t.Errorf("Read invalid data: %v", out)
 	}

--- a/buffer_pool_test.go
+++ b/buffer_pool_test.go
@@ -1,0 +1,41 @@
+package falcore
+
+import (
+/*	"io"*/
+	"bytes"
+	"testing"
+)
+
+func TestBufferPool(t *testing.T){
+	pool := newBufferPool(10, 1024)
+	
+	text := []byte("Hello World")
+	
+	// get one
+	bpe := pool.take(bytes.NewBuffer(text))
+	// read all
+	out := make([]byte, 1024)
+	l, _ := bpe.buf.Read(out)
+	if bytes.Compare(out[0:l], text) != 0 {
+		t.Errorf("Read invalid data: %v", out)
+	}
+	if l != len(text) {
+		t.Errorf("Expected length %v got %v", len(text), l)
+	}
+	pool.give(bpe)
+	
+	
+	// get one
+	bpe = pool.take(bytes.NewBuffer(text))
+	// read all
+	out = make([]byte, 1024)
+	l, _ = bpe.buf.Read(out)
+	if bytes.Compare(out[0:l], text) != 0 {
+		t.Errorf("Read invalid data: %v", out)
+	}
+	if l != len(text) {
+		t.Errorf("Expected length %v got %v", len(text), l)
+	}
+	pool.give(bpe)
+	
+}

--- a/buffer_pool_test.go
+++ b/buffer_pool_test.go
@@ -1,16 +1,16 @@
 package falcore
 
 import (
-/*	"io"*/
+	/*	"io"*/
 	"bytes"
 	"testing"
 )
 
-func TestBufferPool(t *testing.T){
+func TestBufferPool(t *testing.T) {
 	pool := newBufferPool(10, 1024)
-	
+
 	text := []byte("Hello World")
-	
+
 	// get one
 	bpe := pool.take(bytes.NewBuffer(text))
 	// read all
@@ -23,8 +23,7 @@ func TestBufferPool(t *testing.T){
 		t.Errorf("Expected length %v got %v", len(text), l)
 	}
 	pool.give(bpe)
-	
-	
+
 	// get one
 	bpe = pool.take(bytes.NewBuffer(text))
 	// read all
@@ -58,5 +57,4 @@ func TestBufferPool(t *testing.T){
 	}
 	pool.give(bpe)
 
-	
 }

--- a/buffer_pool_test.go
+++ b/buffer_pool_test.go
@@ -37,5 +37,26 @@ func TestBufferPool(t *testing.T){
 		t.Errorf("Expected length %v got %v", len(text), l)
 	}
 	pool.give(bpe)
+
+	// get one
+	bpe = pool.take(bytes.NewBuffer(text))
+	// read 1 byte
+	out = make([]byte, 1)
+	bpe.buf.Read(out)
+	pool.give(bpe)
+
+	// get one
+	bpe = pool.take(bytes.NewBuffer(text))
+	// read all
+	out = make([]byte, 1024)
+	l, _ = bpe.buf.Read(out)
+	if bytes.Compare(out[0:l], text) != 0 {
+		t.Errorf("Read invalid data: %v", out)
+	}
+	if l != len(text) {
+		t.Errorf("Expected length %v got %v", len(text), l)
+	}
+	pool.give(bpe)
+
 	
 }

--- a/server.go
+++ b/server.go
@@ -203,7 +203,7 @@ func (srv *Server) handler(c net.Conn) {
 	reqCount := 0
 	keepAlive := true
 	for err == nil && keepAlive {
-		if req, err = http.ReadRequest(bpe.buf); err == nil {
+		if req, err = http.ReadRequest(bpe.br); err == nil {
 			if req.Header.Get("Connection") != "Keep-Alive" {
 				keepAlive = false
 			}


### PR DESCRIPTION
Added a leaky bucket buffer pool to falcore.Server.  Reusing bufio.Reader instances for new connections.

In the current version, we're allocating a new 8192 byte buffer every time a connection is opened.  It becomes garbage when the client disconnects.  This patch should drastically reduce the amount of garbage created.
