### PR TITLE
Added RewriteHost flag for upstream filter

### DIFF
--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -87,7 +87,7 @@ func (u *Upstream) FilterRequest(request *falcore.Request) (res *http.Response) 
 	}
 	if u.RewriteHost {
 		req.URL.Host = fmt.Sprintf("%v:%v", u.Host, u.Port)
-		req.HttpRequest.Host = fmt.Sprintf("%v:%v", u.Host, u.Port)
+		req.Host = fmt.Sprintf("%v:%v", u.Host, u.Port)
 		falcore.Debug("Host rewritten to %v:%v", u.Host, u.Port)
 	}
 	before := time.Now()

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -46,13 +46,11 @@ func NewUpstream(host string, port int, forceHttp bool, rewriteHost bool) *Upstr
 		u.tcpaddr = new(net.TCPAddr)
 		u.tcpaddr.Port = port
 		u.tcpaddr.IP = ip
-		falcore.Debug("Found %v: %v", host, port)
 	} else {
 		falcore.Warn("Can't get IP addr for %v: %v", host, err)
 	}
 	u.Timeout = 60e9
 	u.host = fmt.Sprintf("%v:%v", u.Host, u.Port)
-	falcore.Debug("Upstream Host %v: %v", host, port)
 
 	u.transport = new(http.Transport)
 
@@ -89,6 +87,8 @@ func (u *Upstream) FilterRequest(request *falcore.Request) (res *http.Response) 
 	}
 	if u.RewriteHost {
 		req.URL.Host = fmt.Sprintf("%v:%v", u.Host, u.Port)
+		req.HttpRequest.Host = fmt.Sprintf("%v:%v", u.Host, u.Port)
+		falcore.Debug("Host rewritten to %v:%v", u.Host, u.Port)
 	}
 	before := time.Now()
 	req.Header.Set("Connection", "Keep-Alive")

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -88,7 +88,6 @@ func (u *Upstream) FilterRequest(request *falcore.Request) (res *http.Response) 
 	if u.RewriteHost {
 		req.URL.Host = fmt.Sprintf("%v:%v", u.Host, u.Port)
 		req.Host = fmt.Sprintf("%v:%v", u.Host, u.Port)
-		falcore.Debug("Host rewritten to %v:%v", u.Host, u.Port)
 	}
 	before := time.Now()
 	req.Header.Set("Connection", "Keep-Alive")
@@ -116,7 +115,11 @@ func (u *Upstream) ping() (up bool, ok bool) {
 	if u.PingPath != "" {
 		// the url must be syntactically valid for this to work but the host will be ignored because we
 		// are overriding the connection always
-		request, err := http.NewRequest("GET", "http://localhost"+u.PingPath, nil)
+		host := "http://localhost"
+		if u.RewriteHost {
+			host = fmt.Sprintf("http://%v:%v", u.Host, u.Port)
+		}
+		request, err := http.NewRequest("GET", host+u.PingPath, nil)
 		request.Header.Set("Connection", "Keep-Alive") // not sure if this should be here for a ping
 		if err != nil {
 			falcore.Error("Bad Ping request: %v", err)

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -86,8 +86,7 @@ func (u *Upstream) FilterRequest(request *falcore.Request) (res *http.Response) 
 		req.URL.Host = req.Host
 	}
 	if u.RewriteHost {
-		req.URL.Host = u.Host
-		req.URL.Port = u.Port
+		req.URL.Host = fmt.Sprintf("%v:%v", u.Host, u.Port)
 	}
 	before := time.Now()
 	req.Header.Set("Connection", "Keep-Alive")

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -46,11 +46,13 @@ func NewUpstream(host string, port int, forceHttp bool, rewriteHost bool) *Upstr
 		u.tcpaddr = new(net.TCPAddr)
 		u.tcpaddr.Port = port
 		u.tcpaddr.IP = ip
+		falcore.Debug("Found %v: %v", host, port)
 	} else {
 		falcore.Warn("Can't get IP addr for %v: %v", host, err)
 	}
 	u.Timeout = 60e9
 	u.host = fmt.Sprintf("%v:%v", u.Host, u.Port)
+	falcore.Debug("Upstream Host %v: %v", host, port)
 
 	u.transport = new(http.Transport)
 

--- a/upstream/upstream_pool.go
+++ b/upstream/upstream_pool.go
@@ -10,10 +10,11 @@ import (
 )
 
 type UpstreamEntryConfig struct {
-	HostPort  string
-	Weight    int
-	ForceHttp bool
-	PingPath  string
+	HostPort    string
+	Weight      int
+	ForceHttp   bool
+	PingPath    string
+	RewriteHost bool
 }
 
 type UpstreamEntry struct {
@@ -59,7 +60,7 @@ func NewUpstreamPool(name string, config []UpstreamEntryConfig) *UpstreamPool {
 				falcore.Error("UpstreamPool Error converting port to int for", upstreamHost, ":", err)
 			}
 		}
-		ups := NewUpstream(upstreamHost, upstreamPort, uec.ForceHttp)
+		ups := NewUpstream(upstreamHost, upstreamPort, uec.ForceHttp, uec.RewriteHost)
 		ups.PingPath = uec.PingPath
 		ue := new(UpstreamEntry)
 		ue.Upstream = ups


### PR DESCRIPTION
I've added the rewrite-host option we discussed in Issue #11. Could you please give it a quick review to make sure I haven't done anything stupid.
## Overview

Simply added a RewriteHost boolean flag to Upstream type. If set to true then the Host header of the request will be rewritten to point to the host and port specified in the Upstream type. This is so that you can have a Falcore server sat on one address proxying upstream requests to a backend on another address.

I've also added this to the ping code too, so that the ping process pings the rewritten host.

I look forward to your feedback.

Cheers,
Ben
