### PR TITLE
file_filter does not return 404 if file isn't found.

### DIFF
--- a/static_file/file_filter.go
+++ b/static_file/file_filter.go
@@ -58,11 +58,9 @@ func (f *Filter) FilterRequest(req *falcore.Request) (res *http.Response) {
 			}
 		} else {
 			file.Close()
-			return falcore.SimpleResponse(req.HttpRequest, 404, nil, "File not found\n")
 		}
 	} else {
-		falcore.Debug("Can't open %v: %v", asset_path, err)
-		res = falcore.SimpleResponse(req.HttpRequest, 404, nil, "File not found\n")
+		falcore.Finest("Can't open %v: %v", asset_path, err)
 	}
 	return
 }


### PR DESCRIPTION
file_filter should not return a 404 if the file isn't found.  it's easy enough to put a 404 responder at the end of the pipeline.  not to mention, developers may want to server their own 404s.  file_filter is way more useful if it doesn't have to be the last filter in the pipeline.
