### PR TITLE
A simpler approach to graceful shutdown

### DIFF
--- a/server.go
+++ b/server.go
@@ -193,7 +193,7 @@ func (srv *Server) serve() (e error) {
 func (srv *Server) sentinel(c net.Conn, connClosed chan int) {
 	select {
 	case <- srv.stopAccepting:
-		c.SetReadDeadline(time.Now())
+		c.SetReadDeadline(time.Now().Add(3 * time.Second))
 	case <- connClosed:
 	}
 }

--- a/server.go
+++ b/server.go
@@ -142,7 +142,7 @@ func (srv *Server) ListenAndServeTLS(certFile, keyFile string) error {
 }
 
 func (srv *Server) StopAccepting() {
-	srv.stopAccepting <- 1
+	close(srv.stopAccepting)
 }
 
 func (srv *Server) Port() int {

--- a/server.go
+++ b/server.go
@@ -230,6 +230,16 @@ func (srv *Server) handler(c net.Conn) {
 			// cleanup
 			request.startPipelineStage("server.ResponseWrite")
 			req.Body.Close()
+
+			// shutting down?
+			select {
+			case <- srv.stopAccepting:
+				keepAlive = false
+				res.Close = true
+			default:
+			}
+
+			// write response
 			wbuf := bufio.NewWriter(c)
 			res.Write(wbuf)
 			wbuf.Flush()


### PR DESCRIPTION
Here's another approach to shutting down gracefully.  It still requires a second goroutine, but it doesn't alter control flow.  The cost of a completely idle goroutine should be just the size of a single stack frame.

When srv.stopAccepting is closed, the ReadTimeout will be set on the connection.  All reads, even an active one, will timeout.  This should not affect writes, so the in flight request can still finish.
