### PR TITLE
String body upgrade

### DIFF
--- a/string_body.go
+++ b/string_body.go
@@ -50,7 +50,9 @@ func (sbf *StringBodyFilter)readRequestBody(r *http.Request) (sb *StringBody, er
 	if strings.SplitN(ct, ";", 2)[0] != "multipart/form-data" && r.ContentLength > 0 {
 		sb = &StringBody{}
 		const maxFormSize = int64(10 << 20) // 10 MB is a lot of text.
-		sb.bpe = sbf.pool.take(io.LimitReader(r.Body, maxFormSize+1))
+		//rr := io.LimitReader(r.Body, maxFormSize+1)
+		rr := r.Body
+		sb.bpe = sbf.pool.take(rr)
 		cumu := time.Since(start)
 		Warn("C1: %v", cumu)
 		b, e := sb.bpe.br.ReadBytes(0)

--- a/string_body.go
+++ b/string_body.go
@@ -56,7 +56,7 @@ func (sbf *StringBodyFilter)readRequestBody(r *http.Request) (sb *StringBody, er
 			return nil, e
 		}
 		sb.BodyBuffer = bytes.NewReader(b)
-		r.Body.Close()
+		go r.Body.Close()
 		r.Body = sb
 		return sb, nil
 	}

--- a/string_body.go
+++ b/string_body.go
@@ -51,9 +51,9 @@ func (sbf *StringBodyFilter)readRequestBody(r *http.Request) (sb *StringBody, er
 		sb = &StringBody{}
 		const maxFormSize = int64(10 << 20) // 10 MB is a lot of text.
 		
-		sb.bpe = sbf.pool.take(io.LimitReader(r.Body, maxFormSize+1))
+		//sb.bpe = sbf.pool.take(io.LimitReader(r.Body, maxFormSize+1))
 		b := make([]byte, r.ContentLength)
-		_, e := sb.bpe.br.Read(b)
+		_, e := r.Body.Read(b)
 		cumu := time.Since(start)
 		if cumu > time.Millisecond {
 			Warn("C2: %v", cumu)
@@ -81,7 +81,7 @@ func (sbf *StringBodyFilter)ReturnBuffer(request *Request) {
 // Insert this in the response pipeline to return the buffer pool for the request body
 // If there is an appropriate place in your flow, you can call ReturnBuffer explicitly
 func (sbf *StringBodyFilter) FilterResponse(request *Request, res *http.Response) {
-	sbf.ReturnBuffer(request)
+	//sbf.ReturnBuffer(request)
 }
 
 

--- a/string_body.go
+++ b/string_body.go
@@ -2,27 +2,34 @@ package falcore
 
 import (
 	"io"
-	"io/ioutil"
+	//"io/ioutil"
 	"net/http"
-
 	"strings"
+	"bytes"
 )
 
 // Keeps the body of a request in a string so it can be re-read at each stage of the pipeline
 // implements io.ReadCloser to match http.Request.Body
 
 type StringBody struct {
-	BodyString string
-	BodyBuffer *strings.Reader
+	BodyBuffer *bytes.Reader
+	bpe *bufferPoolEntry
 }
 
-type StringBodyFilter struct{}
+type StringBodyFilter struct {
+	pool *bufferPool
+}
 
+func NewStringBodyFilter() *StringBodyFilter {
+	sbf := &StringBodyFilter{}
+	sbf.pool = newBufferPool(100, 1024)
+	return sbf
+}
 func (sbf *StringBodyFilter) FilterRequest(request *Request) *http.Response {
 	req := request.HttpRequest
 	// This caches the request body so that multiple filters can iterate it
 	if req.Method == "POST" || req.Method == "PUT" {
-		sb, err := ReadRequestBody(req)
+		sb, err := sbf.readRequestBody(req)
 		if sb == nil || err != nil {
 			request.CurrentStage.Status = 3 // Skip
 			Debug("%s No Req Body or Ignored: %v", request.ID, err)
@@ -35,18 +42,20 @@ func (sbf *StringBodyFilter) FilterRequest(request *Request) *http.Response {
 
 // reads the request body and replaces the buffer with self
 // returns nil if the body is multipart and not replaced
-func ReadRequestBody(r *http.Request) (sb *StringBody, err error) {
+func (sbf *StringBodyFilter)readRequestBody(r *http.Request) (sb *StringBody, err error) {
 	ct := r.Header.Get("Content-Type")
 	// leave it on the buffer if we're multipart
 	if strings.SplitN(ct, ";", 2)[0] != "multipart/form-data" && r.ContentLength > 0 {
-		sb = new(StringBody)
+		sb = &StringBody{}
 		const maxFormSize = int64(10 << 20) // 10 MB is a lot of text.
-		b, e := ioutil.ReadAll(io.LimitReader(r.Body, maxFormSize+1))
-		if e != nil {
+		sb.bpe = sbf.pool.take(io.LimitReader(r.Body, maxFormSize+1))
+		
+		b, e := sb.bpe.br.ReadBytes(0)
+		//Error("B: %v, E: %v\n", b, e)
+		if e != nil && e != io.EOF {
 			return nil, e
 		}
-		sb.BodyString = string(b)
-		sb.Close() // to create our buffer
+		sb.BodyBuffer = bytes.NewReader(b)
 		r.Body.Close()
 		r.Body = sb
 		return sb, nil
@@ -54,12 +63,27 @@ func ReadRequestBody(r *http.Request) (sb *StringBody, err error) {
 	return nil, nil // ignore	
 }
 
+// Returns a buffer used in the FilterRequest stage to a buffer pool
+// this speeds up this filter significantly by reusing buffers
+func (sbf *StringBodyFilter)ReturnBuffer(request *Request) {
+	if sb, ok := request.HttpRequest.Body.(*StringBody); ok {
+		sbf.pool.give(sb.bpe)	
+	}
+}
+
+// Insert this in the response pipeline to return the buffer pool for the request body
+// If there is an appropriate place in your flow, you can call ReturnBuffer explicitly
+func (sbf *StringBodyFilter) FilterResponse(request *Request, res *http.Response) {
+	sbf.ReturnBuffer(request)
+}
+
+
 func (sb *StringBody) Read(b []byte) (n int, err error) {
 	return sb.BodyBuffer.Read(b)
 }
 
 func (sb *StringBody) Close() error {
 	// start over
-	sb.BodyBuffer = strings.NewReader(sb.BodyString)
+	sb.BodyBuffer.Seek(0, 0)
 	return nil
 }

--- a/string_body_test.go
+++ b/string_body_test.go
@@ -2,10 +2,10 @@ package falcore
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
-	"io/ioutil"
 	//"io"
 )
 
@@ -68,7 +68,7 @@ func BenchmarkStringBody(b *testing.B) {
 	sbf := NewStringBodyFilter()
 	//sbf := &StringBodyFilter{}
 
-    for i := 0; i < b.N; i++ {
+	for i := 0; i < b.N; i++ {
 		tmp, _ := http.NewRequest("POST", "/hello", bytes.NewReader(expected))
 		tmp.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		tmp.ContentLength = expLen
@@ -84,6 +84,6 @@ func BenchmarkStringBody(b *testing.B) {
 		io.CopyN(ioutil.Discard, req.HttpRequest.Body, req.HttpRequest.ContentLength)
 		req.HttpRequest.Body	.Close()		
 		*/
-		b.StopTimer()    		
-    }
+		b.StopTimer()
+	}
 }


### PR DESCRIPTION
I updated the string body request to use the buffer pool and some other better buffer management. Added a benchmark for it and reduced time from ~5us to about 3us on my laptop.

This changes the exposed interface fairly significantly; but I doubt anyone was looking at the buffer or string directly. I need to return the buffer to the pool which is done in a response filter.

This has a bunch of commits because of some more extensive debug of this filter that was actually a bad client implementation.
