### PR TITLE
Handler func filter

### DIFF
--- a/handler_filter.go
+++ b/handler_filter.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 )
 
-// Implements the RequestFilter using a http.Handleer to produce the response
-// This will always return a response due to the requirements of the http.HandleFunc
-// interface.
+// Implements a RequestFilter using a http.Handler to produce the response
+// This will always return a response due to the requirements of the http.Handler
+// interface so it should be placed at the end of the Upstream pipeline.
 type HandlerFilter struct {
 	handler http.Handler
 }

--- a/handler_filter.go
+++ b/handler_filter.go
@@ -6,23 +6,23 @@ import (
 	"fmt"
 )
 
-// Implements the RequestFilter using a http.HandleFunc to produce the response
+// Implements the RequestFilter using a http.Handleer to produce the response
 // This will always return a response due to the requirements of the http.HandleFunc
 // interface.
-type HandlerFuncFilter struct {
-	handler http.HandlerFunc
+type HandlerFilter struct {
+	handler http.Handler
 }
 
-func NewHandlerFuncFilter(handler http.HandlerFunc) (*HandlerFuncFilter) {
-	return &HandlerFuncFilter{ handler: handler}
+func NewHandlerFilter(handler http.Handler) (*HandlerFilter) {
+	return &HandlerFilter{ handler: handler}
 }
 
-func (h *HandlerFuncFilter) FilterRequest(req *Request) *http.Response {
+func (h *HandlerFilter) FilterRequest(req *Request) *http.Response {
 	rw, respc := newPopulateResponseWriter()
 	// this must be done concurrently so that the HandlerFunc can write the response
 	// while falcore is copying it to the socket
 	go func() {
-		h.handler(rw, req.HttpRequest)
+		h.handler.ServeHTTP(rw, req.HttpRequest)
 		rw.finish()
 	}()
 	return <-respc

--- a/handler_filter.go
+++ b/handler_filter.go
@@ -18,7 +18,7 @@ func NewHandlerFilter(handler http.Handler) (*HandlerFilter) {
 }
 
 func (h *HandlerFilter) FilterRequest(req *Request) *http.Response {
-	rw, respc := newPopulateResponseWriter()
+	rw, respc := newPopulateResponseWriter(req.HttpRequest)
 	// this must be done concurrently so that the HandlerFunc can write the response
 	// while falcore is copying it to the socket
 	go func() {
@@ -29,7 +29,7 @@ func (h *HandlerFilter) FilterRequest(req *Request) *http.Response {
 }
 
 // copied from net/http/filetransport.go
-func newPopulateResponseWriter() (*populateResponse, <-chan *http.Response) {
+func newPopulateResponseWriter(req *http.Request) (*populateResponse, <-chan *http.Response) {
 	pr, pw := io.Pipe()
 	rw := &populateResponse{
 		ch: make(chan *http.Response),
@@ -40,6 +40,7 @@ func newPopulateResponseWriter() (*populateResponse, <-chan *http.Response) {
 			Header:     make(http.Header),
 			Close:      true,
 			Body:       pr,
+			Request:	    req,
 		},
 	}
 	return rw, rw.ch

--- a/handler_filter_test.go
+++ b/handler_filter_test.go
@@ -7,13 +7,13 @@ import (
 	"io/ioutil"
 )
 
-func TestHandlerFuncFilter(t *testing.T) {
+func TestHandlerFilter(t *testing.T) {
 	reply := "Hello, World"
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, reply)
 	}
 	
-	hff := NewHandlerFuncFilter(handler)
+	hff := NewHandlerFilter(http.HandlerFunc(handler))
 
 	tmp, _ := http.NewRequest("GET", "/hello", nil)
 	_, res := TestWithRequest(tmp, hff)


### PR DESCRIPTION
Umm.. this was just wrong before.  Fixed to use the http.Handler interface rather than the helper function type.
