### PR TITLE
Fixed issue #10, now builds in windows

### DIFF
--- a/server.go
+++ b/server.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"reflect"
 	"runtime"
 	"strconv"
 	"sync"
@@ -87,37 +86,8 @@ func (srv *Server) socketListen() error {
 	srv.listener = l
 	// setup listener to be non-blocking if we're not on windows.
 	// this is required for hot restart to work.
-	if runtime.GOOS != "windows" {
-		if srv.listenerFile, err = l.File(); err != nil {
-			return err
-		}
-		fd := int(srv.listenerFile.Fd())
-		if e := setupFDNonblock(fd); e != nil {
-			return e
-		}
-
-		if srv.sendfile {
-			if e := syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, srv.sockOpt, 1); e != nil {
-				return e
-			}
-		}
-	}
-	return nil
-}
-
-// Calling syscall.SetNonblock using reflection to avoid compile errors
-// on windows.  This call is not used on windows as hot restart is not supported.
-func setupFDNonblock(fd int) error {
-	// if function exists
-	if fun := reflect.ValueOf(syscall.SetNonblock); fun.Kind() == reflect.Func {
-		// if first argument is an int
-		if fun.Type().In(0).Kind() == reflect.Int {
-			args := []reflect.Value{reflect.ValueOf(fd), reflect.ValueOf(true)}
-			if res := fun.Call(args); len(res) == 1 && !res[0].IsNil() {
-				err := res[0].Interface().(error)
-				return err
-			}
-		}
+	if e := SetupNonBlockingListener(srv, err, l); e != nil {
+		return e
 	}
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -86,10 +86,7 @@ func (srv *Server) socketListen() error {
 	srv.listener = l
 	// setup listener to be non-blocking if we're not on windows.
 	// this is required for hot restart to work.
-	if e := SetupNonBlockingListener(srv, err, l); e != nil {
-		return e
-	}
-	return nil
+	return srv.setupNonBlockingListener(err, l)
 }
 
 func (srv *Server) ListenAndServe() error {

--- a/server_notwindows.go
+++ b/server_notwindows.go
@@ -4,20 +4,18 @@ package falcore
 
 import (
 	"net"
-	"reflect"
 	"syscall"
 )
 
 // only valid on non-windows
-func SetupNonBlockingListener(srv *Server, err error, l *net.TCPListener) error {
+func (srv *Server) setupNonBlockingListener(srv *Server, err error, l *net.TCPListener) error {
 	if srv.listenerFile, err = l.File(); err != nil {
 		return err
 	}
 	fd := int(srv.listenerFile.Fd())
-	if e := setupFDNonblock(fd); e != nil {
-		return e
-	}
-
+    if e := syscall.SetNonblock(fd); e != nil {
+        return e
+    }
 	if srv.sendfile {
 		if e := syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, srv.sockOpt, 1); e != nil {
 			return e
@@ -25,19 +23,3 @@ func SetupNonBlockingListener(srv *Server, err error, l *net.TCPListener) error 
 	}
 }
 
-// Calling syscall.SetNonblock using reflection to avoid compile errors
-// on windows.  This call is not used on windows as hot restart is not supported.
-func setupFDNonblock(fd int) error {
-	// if function exists
-	if fun := reflect.ValueOf(syscall.SetNonblock); fun.Kind() == reflect.Func {
-		// if first argument is an int
-		if fun.Type().In(0).Kind() == reflect.Int {
-			args := []reflect.Value{reflect.ValueOf(fd), reflect.ValueOf(true)}
-			if res := fun.Call(args); len(res) == 1 && !res[0].IsNil() {
-				err := res[0].Interface().(error)
-				return err
-			}
-		}
-	}
-	return nil
-}

--- a/server_notwindows.go
+++ b/server_notwindows.go
@@ -8,18 +8,18 @@ import (
 )
 
 // only valid on non-windows
-func (srv *Server) setupNonBlockingListener(srv *Server, err error, l *net.TCPListener) error {
+func (srv *Server) setupNonBlockingListener(err error, l *net.TCPListener) error {
 	if srv.listenerFile, err = l.File(); err != nil {
 		return err
 	}
 	fd := int(srv.listenerFile.Fd())
-    if e := syscall.SetNonblock(fd); e != nil {
-        return e
-    }
+	if e := syscall.SetNonblock(fd, true); e != nil {
+		return e
+	}
 	if srv.sendfile {
 		if e := syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, srv.sockOpt, 1); e != nil {
 			return e
 		}
 	}
+	return nil
 }
-

--- a/server_notwindows.go
+++ b/server_notwindows.go
@@ -1,0 +1,43 @@
+// +build !windows
+
+package falcore
+
+import (
+	"net"
+	"reflect"
+	"syscall"
+)
+
+// only valid on non-windows
+func SetupNonBlockingListener(srv *Server, err error, l *net.TCPListener) error {
+	if srv.listenerFile, err = l.File(); err != nil {
+		return err
+	}
+	fd := int(srv.listenerFile.Fd())
+	if e := setupFDNonblock(fd); e != nil {
+		return e
+	}
+
+	if srv.sendfile {
+		if e := syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, srv.sockOpt, 1); e != nil {
+			return e
+		}
+	}
+}
+
+// Calling syscall.SetNonblock using reflection to avoid compile errors
+// on windows.  This call is not used on windows as hot restart is not supported.
+func setupFDNonblock(fd int) error {
+	// if function exists
+	if fun := reflect.ValueOf(syscall.SetNonblock); fun.Kind() == reflect.Func {
+		// if first argument is an int
+		if fun.Type().In(0).Kind() == reflect.Int {
+			args := []reflect.Value{reflect.ValueOf(fd), reflect.ValueOf(true)}
+			if res := fun.Call(args); len(res) == 1 && !res[0].IsNil() {
+				err := res[0].Interface().(error)
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/server_windows.go
+++ b/server_windows.go
@@ -6,6 +6,6 @@ import (
 )
 
 // only valid on non-windows
-func SetupNonBlockingListener(srv *Server, err error, l *net.TCPListener) error {
+func (srv *Server) setupNonBlockingListener(err error, l *net.TCPListener) error {
 	return nil
 }

--- a/server_windows.go
+++ b/server_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+package falcore
+
+import (
+	"net"
+)
+
+// only valid on non-windows
+func SetupNonBlockingListener(srv *Server, err error, l *net.TCPListener) error {
+	return nil
+}


### PR DESCRIPTION
Used build constraints to break off windows and non-windows functionality for the non-blocking listener.
