### PR TITLE
Forcing Transfer-encoding: chunked on Content-length: 0

### DIFF
--- a/server.go
+++ b/server.go
@@ -231,6 +231,17 @@ func (srv *Server) handler(c net.Conn) {
 				res.Close = true
 			default:
 			}
+			// The res.Write omits Content-length on 0 length bodies, and by spec, 
+			// it SHOULD. While this is not MUST, it's kinda broken.  See sec 4.4 
+			// of rfc2616 and a 200 with a zero length does not satisfy any of the
+			// 5 conditions if Connection: keep-alive is set :(
+			// I'm forcing chunked which seems to work because I couldn't get the
+			// content length to write if it was 0.
+			// Specifically, the android http client waits forever if there's no
+			// content-length instead of assuming zero at the end of headers. der.
+			if res.ContentLength == 0 && len(res.TransferEncoding) == 0 {
+				res.TransferEncoding = []string{"chunked"}
+			}
 
 			// write response
 			if srv.sendfile {

--- a/server.go
+++ b/server.go
@@ -239,8 +239,8 @@ func (srv *Server) handler(c net.Conn) {
 			// content length to write if it was 0.
 			// Specifically, the android http client waits forever if there's no
 			// content-length instead of assuming zero at the end of headers. der.
-			if res.ContentLength == 0 && len(res.TransferEncoding) == 0 {
-				res.TransferEncoding = []string{"chunked"}
+			if res.ContentLength == 0 && len(res.TransferEncoding) == 0 && !((res.StatusCode-100 < 100) || res.StatusCode == 204 || res.StatusCode == 304) {
+				res.TransferEncoding = []string{"identity"}
 			}
 
 			// write response


### PR DESCRIPTION
Workaround for corner case.  This is likely a bug in go with the response.Write().  It always omits the Content-Length header if it is zero.  Apparently, some clients can't handle that.
