### PR TITLE
Fix for #32: Cycle TCP_CORK/TCP_NOPUSH flag between messages

### DIFF
--- a/server.go
+++ b/server.go
@@ -249,6 +249,7 @@ func (srv *Server) handler(c net.Conn) {
 			// write response
 			if srv.sendfile {
 				res.Write(c)
+				srv.cycleNonBlock(c)
 			} else {
 				wbuf := bufio.NewWriter(c)
 				res.Write(wbuf)

--- a/server_windows.go
+++ b/server_windows.go
@@ -9,3 +9,7 @@ import (
 func (srv *Server) setupNonBlockingListener(err error, l *net.TCPListener) error {
 	return nil
 }
+
+func (srv *Server) cycleNonBlock(c *net.Conn) {
+	// nuthin
+}


### PR DESCRIPTION
See #32 for more details.
