### PR TITLE
Upstream copies request instead of passing it thru

### DIFF
--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -101,6 +101,7 @@ func (u *Upstream) FilterRequest(request *falcore.Request) (res *http.Response) 
 		// Copy response over to new record.  Remove connection noise.  Add some sanity.
 		res = falcore.SimpleResponse(req, upstrRes.StatusCode, nil, "")
 		if upstrRes.ContentLength > 0 && upstrRes.Body != nil {
+			res.ContentLength = upstrRes.ContentLength
 			res.Body = upstrRes.Body
 		} else if upstrRes.ContentLength == 0 && upstrRes.Body != nil {
 			// Any bytes?

--- a/upstream/upstream.go
+++ b/upstream/upstream.go
@@ -109,6 +109,7 @@ func (u *Upstream) FilterRequest(request *falcore.Request) (res *http.Response) 
 			if n == 1 {
 				// Yes there are.  Chunked it is.
 				res.TransferEncoding = []string{"chunked"}
+				res.ContentLength = -1
 				rc := &passThruReadCloser{
 					io.MultiReader(bytes.NewBuffer(testBuf[:]), upstrRes.Body),
 					upstrRes.Body,
@@ -118,6 +119,7 @@ func (u *Upstream) FilterRequest(request *falcore.Request) (res *http.Response) 
 			}
 		} else if upstrRes.Body != nil {
 			res.Body = upstrRes.Body
+			res.ContentLength = -1
 			res.TransferEncoding = []string{"chunked"}
 		}
 		// Copy over headers with a few exceptions


### PR DESCRIPTION
We kept running into issues with connection management and content lengths.  The root cause seems to be that an http.Response read from the wire is not setup to be written back to the wire.  After fighting with prematurely closed downstream connections, duplicated status codes, and numerous content-lenght issues, it seems we shouldn't be reusing that object.

This patch fixes several issues by creating a new response and copying over the appropriate bits.  It also applies sane logic to content-length and transfer-encoding.  

For example, an upstream that uses connection closing to terminate a response body (for shame) will no longer cause the downstream connection to be shut.  Instead, this will be converted to a chunk encoded message on the downstream and keepalives can happily be observed.
