### PR TITLE
fix typo in windows support

### DIFF
--- a/server_windows.go
+++ b/server_windows.go
@@ -10,6 +10,6 @@ func (srv *Server) setupNonBlockingListener(err error, l *net.TCPListener) error
 	return nil
 }
 
-func (srv *Server) cycleNonBlock(c *net.Conn) {
+func (srv *Server) cycleNonBlock(c net.Conn) {
 	// nuthin
 }


### PR DESCRIPTION
There's a typo in `server_windows.go`.  `net.Conn` is an interface.
