### PR TITLE
Add context to test requests

### DIFF
--- a/request.go
+++ b/request.go
@@ -75,8 +75,9 @@ func newRequest(request *http.Request, conn net.Conn, startTime time.Time) *Requ
 // Returns a completed falcore.Request and response after running the single filter stage
 // The PipelineStageStats is completed in the returned Request 
 // The falcore.Request.Connection and falcore.Request.RemoteAddr are nil
-func TestWithRequest(request *http.Request, filter RequestFilter) (*Request, *http.Response) {
+func TestWithRequest(request *http.Request, filter RequestFilter, context map[string]interface{}) (*Request, *http.Response) {
 	r := newRequest(request, nil, time.Now())
+	r.Context = context
 	t := reflect.TypeOf(filter)
 	r.startPipelineStage(t.String())
 	res := filter.FilterRequest(r)


### PR DESCRIPTION
The current API doesn't provide for including context when testing filters.  This is important for testing filters in isolation that may depend on context set elsewhere.
