### PR TITLE
Set the socket back to nonblock

### DIFF
--- a/server.go
+++ b/server.go
@@ -246,6 +246,12 @@ func (srv *Server) handler(c net.Conn) {
 				res.TransferEncoding = []string{"chunked"}
 			}
 
+			// For HTTP/1.0 and Keep-Alive, sending the Connection: Keep-Alive response header is required
+			// because close is default (opposite of 1.1)
+			if keepAlive && !req.ProtoAtLeast(1, 1) {
+				res.Header.Add("Connection", "Keep-Alive")
+			}
+
 			// write response
 			if srv.sendfile {
 				res.Write(c)

--- a/server_notwindows.go
+++ b/server_notwindows.go
@@ -38,6 +38,7 @@ func (srv *Server) cycleNonBlock(c net.Conn) {
 				c.Write([]byte{})
 				// Re-enable TCP_CORK/TCP_NOPUSH
 				syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, srv.sockOpt, 1)
+				syscall.SetNonblock(fd, true)
 			}
 		}
 	}


### PR DESCRIPTION
when go makes a blocking syscall, it does it in a thread so the main process isn't blocked.  calling File() on the socket sets it to blocking (I don't know why goteam did that).  So every read/write to that socket causes threads to be spawned.  Under heavy load I was leaking threads badly and each sucks up 8M of virtual memory.

this patch works, but I think we should consider pulling the TCPCORK out of falcore entirely.  I think it's more likely that we will end up interfering with go's internal optimizations rather than reaping the benefits of messing with the socket params.
